### PR TITLE
Adding Chat ID validation mechanism for private bots

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,7 +7,7 @@ import (
 
 var config struct {
 	BotToken string
-	//TODO: ChatIds []string
+	ChatIds []int64
 	Espurna struct {
 		Relay    int `json:",omitempty"`
 		Hostname string
@@ -23,7 +23,7 @@ func init() {
 	if err = json.NewDecoder(f).Decode(&config); err != nil {
 		panic(err)
 	}
-	if config.BotToken == "" || config.Espurna.ApiKey == "" || config.Espurna.Hostname == "" {
+	if config.BotToken == "" || config.Espurna.ApiKey == "" || config.Espurna.Hostname == "" || len(config.ChatIds) == 0 {
 		panic("json invalid")
 	}
 	// if not relay specified 0 should be chosen. done with go zero value

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,9 @@
+{
+	"BotToken": "<BotToken">,
+	"ChatIds" [<ChatId>],
+	"Espurna": {
+		"Relay": 0,
+		"Hostname": "<Hostname>",
+		"ApiKey": "<ApiKey"
+	}
+}

--- a/config.json.example
+++ b/config.json.example
@@ -1,9 +1,9 @@
 {
-	"BotToken": "<BotToken">,
-	"ChatIds" [<ChatId>],
-	"Espurna": {
-		"Relay": 0,
-		"Hostname": "<Hostname>",
-		"ApiKey": "<ApiKey"
+	"botToken": "<botToken">,
+	"chatIds" [<chatId>],
+	"espurna": {
+		"relay": 0,
+		"hostname": "<hostname>",
+		"apiKey": "<apiKey>"
 	}
 }

--- a/main.go
+++ b/main.go
@@ -26,12 +26,28 @@ func init() {
 	)
 }
 
+func validateChatIds(upd *tb.Update) bool {
+	if upd.Message == nil {
+		return true
+	}
+
+	for _, cid := range config.ChatIds {
+		if cid == upd.Message.Chat.ID {
+			return true
+		}
+	}
+
+	return false
+}
+
 func main() {
 	a := api.NewAPI(config.Espurna.ApiKey, config.Espurna.Hostname, config.Espurna.Relay)
 
+	poller := &tb.LongPoller{Timeout: 10 * time.Second}
+	privateBotPoller := tb.NewMiddlewarePoller(poller, validateChatIds)
 	b, err := tb.NewBot(tb.Settings{
 		Token:  config.BotToken,
-		Poller: &tb.LongPoller{Timeout: 10 * time.Second},
+		Poller: privateBotPoller,
 	})
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This commit forces the user to add one or more chat ids to the config
file, protecting against any sort of stuff against the Espurna unit.