### PR TITLE
Fix config.json.example due to JSON syntax errors

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -1,14 +1,14 @@
 {
-	"botToken": "<botToken">,
-	"chatIds" [<chatId>],
+	"botToken": "<botToken>",
+	"chatIds": [<chatId>],
 	"watchdog": false,
 	"espurna": {
 		"relay": 0,
 		"hostname": "<hostname>",
 		"apiKey": "<apiKey>"
-	}
-	"triggers" : {
-	    "on" {
+	},
+	"triggers": {
+	    "on": {
 	        "The relay is on for %s": ["30m", "1h"],
 	        "The relay on for a long time!": ["2h"]
 	    }


### PR DESCRIPTION
The example file is not being paresd properly due to syntax errors.